### PR TITLE
Unit-Tests fixup & sync with v1.4 protlib-changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name = "protlib2",
-    version = "1.3",
+    version = "1.4",
     py_modules = ["protlib2"],
     cmdclass = {'build_py': build_py},
     

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -115,8 +115,8 @@ class CTypeTests(TestCase):
     def test_valid_basic(self):
         for always in [None, 5]:
             for default in [None, 6]:
-                for ctype in [CChar,  CShort,  CInt,  CLong,
-                              CUChar, CUShort, CUInt, CULong,
+                for ctype in [CChar,  CShort,  CInt,  CLong, CLongLong,
+                              CUChar, CUShort, CUInt, CULong, CULongLong,
                               CFloat, CDouble]:
                     ctype(always=always, default=default)
                 CString(length=5, always=always, default=default)
@@ -133,7 +133,7 @@ class CTypeTests(TestCase):
         self.assertRaises(CError, CArray(2,CInt).parse, b"1234")
     
     def test_integer_boundaries(self):
-        for signed,unsigned,exp in [(CChar,CUChar,8), (CShort,CUShort,16), (CInt,CUInt,32), (CLong,CULong,64)]:
+        for signed,unsigned,exp in [(CChar,CUChar,8), (CShort,CUShort,16), (CInt,CUInt,32), (CLong,CULong,32), (CLongLong,CULongLong,64)]:
             unsigned().serialize(0)
             unsigned().serialize(2**exp - 1)
             self.assertRaises(CError, unsigned().serialize, -1)


### PR DESCRIPTION
- Unit-Tests had to be adjusted due to Long/LongLong changes (PR: #1) 
- Synced changes from original protlib v1.4(http://courtwright.org/protlib/protlib.tar.gz) 
